### PR TITLE
add support for numeric types in bigquery

### DIFF
--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -54,6 +54,7 @@ _type_map = {
     'BYTES': types.BINARY,
     'TIME': types.TIME,
     'RECORD': types.JSON,
+    'NUMERIC': types.Numeric,
 }
 
 


### PR DESCRIPTION
BigQuery has a Numeric Type: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric-type

As per recommendation here:
https://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.Numeric